### PR TITLE
Fix remote code execution vulnerability

### DIFF
--- a/oauth1-python-3legged/complete.py
+++ b/oauth1-python-3legged/complete.py
@@ -22,7 +22,7 @@ class dotdict(dict):
 '''
 def main():
     #create new smart cookie to extract request token
-    cookie = Cookie.SmartCookie()
+    cookie = Cookie.SimpleCookie()
     
     #if a cookie is available, load it
     if os.environ.has_key('HTTP_COOKIE'):


### PR DESCRIPTION
SmartCookie as well as SerialCookie are vulnerable to code injection in python2.
For example, the following cookie header would shutdown your server:
Cookie: foo="cposix\012_exit\012p1\012(I1\012tp2\012Rp3\012."
